### PR TITLE
Backfill missing lab metadata

### DIFF
--- a/Labguide/Usecase 01/Usecase01.md
+++ b/Labguide/Usecase 01/Usecase01.md
@@ -1,3 +1,12 @@
+---
+lab:
+  title: 'Usecase 1: Creating a Lakehouse, ingesting sample data and building a report'
+  description: In this exercise, you ingest additional dimensional and fact tables from the Wide World Importers (WWI) into the lakehouse.
+  duration: 5 minutes
+  level: 300
+  islab: true
+---
+
 # Usecase 1: Creating a Lakehouse, ingesting sample data and building a report
 
 **Introduction**

--- a/Labguide/Usecase 02/Usecase02.md
+++ b/Labguide/Usecase 02/Usecase02.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: 'Usecase 02: Data Factory solution for moving and transforming data with dataflows and data pipelines'
+  description: This lab helps you accelerate the evaluation process for Data Factory in Microsoft Fabric by providing a step-by-step guidance for a full data integration scenario within one hour. By the end of this tutorial, you understand the value and key capabilities of Data Factory and know how to complete a common end-to-end data integration scenario.
+  duration: 5 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Microsoft Fabric
+---
+
 # Usecase 02: Data Factory solution for moving and transforming data with dataflows and data pipelines
 
 **Introduction**

--- a/Labguide/Usecase 03/Usecase03.md
+++ b/Labguide/Usecase 03/Usecase03.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: Usecase 03- Chat with your data using Fabric Data Agent
+  description: In this lab, you learned how to unlock the power of conversational analytics using Microsoft Fabric’s Data Agent. You configured a Fabric workspace, ingested structured data into a lakehouse, and set up an AI skill to translate natural language questions into SQL queries. You also enhanced the AI agent’s capabilities by providing instructions and examples to refine query generation. Finally, you called the agent programmatically from a Fabric notebook, demonstrating end-to-end AI integration. This lab empowers you to make enterprise data more accessible, usable, and intelligent for business users through natural language and generative AI technologies.
+  duration: 5 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Microsoft Fabric
+---
+
 # Usecase 03- Chat with your data using Fabric Data Agent
 
 **Introduction:**

--- a/Labguide/Usecase 04/Usecase04.md
+++ b/Labguide/Usecase 04/Usecase04.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: 'Usecase 04: Analyze data with Apache Spark'
+  description: In this exercise, you’ve learned how to use Spark to work with data in Microsoft Fabric.
+  duration: 5 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Microsoft Fabric
+---
+
 # Usecase 04: Analyze data with Apache Spark
 
 **Introduction**

--- a/Labguide/Usecase 05/Usecase05.md
+++ b/Labguide/Usecase 05/Usecase05.md
@@ -1,3 +1,16 @@
+---
+lab:
+  title: 'Exercise 1: Create a Microsoft Fabric workspace'
+  description: In this lab, you’ll assume the role of a data engineer at Contoso tasked with designing and implementing a data warehouse solution using Microsoft Fabric. You will start by setting up a Fabric workspace, creating a data warehouse, loading data from Azure Blob Storage, and performing analytical tasks to deliver insights to Contoso's decision-makers.
+  duration: 5 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Blob Storage
+    - Microsoft Fabric
+---
+
 ## **Use case 05-Building a Sales and Geography Data Warehouse for Contoso in Microsoft Fabric** 
 
 **Introduction**

--- a/Labguide/Usecase 06/Usecase06.md
+++ b/Labguide/Usecase 06/Usecase06.md
@@ -1,3 +1,15 @@
+---
+lab:
+  title: 'Use case 06: Identifying and extracting text with Document Intelligence in Microsoft Fabric'
+  description: Azure AI Search using the Azure AI Search REST API. This code creates an index with fields for the unique identifier of each document, the text content of the document, and the vector embedding of the text content.
+  duration: 5 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Microsoft Fabric
+---
+
 # Use case 06: Identifying and extracting text with Document Intelligence in Microsoft Fabric
 
 **Introduction**

--- a/Labguide/Usecase/Usecase02.md
+++ b/Labguide/Usecase/Usecase02.md
@@ -1,3 +1,12 @@
+---
+lab:
+  title: Install fixed version of packages
+  description: select Create. When provisioning is complete, the lakehouse explorer page is shown.
+  duration: 5 minutes
+  level: 300
+  islab: true
+---
+
 ## Use Case 04 - Perform Sentiment analysis and Text translation with AI functions in Microsoft Fabric
 
 **Introduction**


### PR DESCRIPTION
## Backfill missing lab metadata

This PR adds structured YAML front matter to lab markdown files.

**Fields added (where missing):** title, description, duration, level, islab, primarytopics

**Behavior:**
- Add-only (does not overwrite existing metadata keys)
- Values inferred from lab content using rule-based heuristics (no AI)
- Content owners should review and adjust values as needed

**Files updated:** 7
**Target branch:** `Cloud-slice`
